### PR TITLE
Refactor: Abstraction of the AI providers into a single class

### DIFF
--- a/core/query_processing.py
+++ b/core/query_processing.py
@@ -1,4 +1,4 @@
-from core.ai_client import classify_query, query_ai
+from core.ai_client import AIClient
 from fastapi import HTTPException
 from handlers.file_handler import FileSearchQuery
 from handlers.ip_handler import IPSearchQuery
@@ -6,9 +6,10 @@ from handlers.url_handler import URLSearchQuery
 from handlers.domain_handler import DomainSearchQuery
 from utils.json_to_vt import convert_query_to_vt_format
 from utils.json_from_text import extract_json_from_text
+import json
 
 # Generalized function to process any category
-def process_generic_query(user_input: str, schema_model):
+def process_generic_query(client: AIClient, user_input: str, schema_model):
     prompt = f"""
     Extract structured data from the following natural language query, without explaining ANYTHING. DO NOT EXPLAIN ANYTHING.
     Use the following schema to construct the JSON where some field has:
@@ -21,7 +22,7 @@ def process_generic_query(user_input: str, schema_model):
     """
     
     print("Sending prompt to AI model...")
-    response = query_ai(prompt)
+    response = client.query_ai(prompt)
     print(response)
     
     try:
@@ -34,8 +35,8 @@ def process_generic_query(user_input: str, schema_model):
     except json.JSONDecodeError:
         return {"error": "Could not interpret the response."}
 
-def process_query(query: str, category: str = None):
-    category = category or classify_query(query)
+def process_query(client: AIClient, query: str, category: str = None):
+    category = category or client.classify_query(query)
     
     print("Category:", category)
     

--- a/core/security_check.py
+++ b/core/security_check.py
@@ -1,6 +1,6 @@
-from core.ai_client import query_ai
+from core.ai_client import AIClient
 
-def is_security_query(text: str) -> bool:
+def is_security_query(client: AIClient, text: str) -> bool:
     """Check if the query is related to security analysis."""
     validation_prompt = """You are a computer science query validator. Determine if the query is related to malware, files, domains, IP, or URLs.
     Return ONLY "true" or "false". Do not give any additional explanation.
@@ -17,6 +17,5 @@ def is_security_query(text: str) -> bool:
     {text}
     
     Output (true/false):"""
-    
-    response = query_ai(validation_prompt.format(text=text)).strip().lower()
+    response = client.query_ai(validation_prompt.format(text=text)).strip().lower()
     return "true" in response

--- a/core/text_utils.py
+++ b/core/text_utils.py
@@ -1,4 +1,5 @@
-def translate_to_english(text: str) -> str:
-    from core.ai_client import query_ai
+from core.ai_client import AIClient
+
+def translate_to_english(client: AIClient, text: str) -> str:
     translation_prompt = f"Translate this text to English, without replying. Only output the translation, nothing else: \n{text}"
-    return query_ai(translation_prompt)
+    return client.query_ai(translation_prompt)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from core.query_processing import process_query
 from core.input_validation import is_raw_input
 from core.text_utils import translate_to_english
 from core.security_check import is_security_query
+from core.ai_client import AIClient
 
 app = FastAPI()
 
@@ -28,9 +29,10 @@ async def query_api(request: QueryRequest):
     if is_raw:
         return {"formatted_query": request.query, "vt_format": request.query, "category": input_type}
     
-    translated_query = translate_to_english(request.query)
+    client = AIClient("Gemini")  # default provider
+    translated_query = translate_to_english(client, request.query)
     
-    if not is_security_query(translated_query):
+    if not is_security_query(client, translated_query):
         return {"formatted_query": "Mmmm... Are you sure you're asking about malware?", "vt_format": "Mmmm... Are you sure you're asking about malware?", "category": "Error"}
     
-    return process_query(translated_query, request.category)
+    return process_query(client, translated_query, request.category)

--- a/test_gemini.py
+++ b/test_gemini.py
@@ -1,9 +1,4 @@
-import google.generativeai as genai
-import os
-from core.ai_client import query_gemini
-
-# Configurar la API Key
-genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
+from core.ai_client import AIClient
 
 def test_gemini_query():
     """Prueba la función query_gemini para verificar la conexión con Gemini y la respuesta."""
@@ -11,7 +6,8 @@ def test_gemini_query():
 
     try:
         print("🔄 Enviando consulta a Gemini...")
-        response = query_gemini(test_prompt)
+        client = AIClient("Gemini")
+        response = client.query_ai(test_prompt)
 
         if response:
             print("✅ Conexión exitosa con Gemini!")

--- a/test_pipeline.py
+++ b/test_pipeline.py
@@ -1,7 +1,7 @@
 import logging
 from core.logical_conversion import convert_to_logical_expression
 from handlers.modifier_handler import process_logical_query
-from core.ai_client import classify_query
+from core.ai_client import AIClient
 
 # Configurar logging para mostrar información detallada
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -16,7 +16,8 @@ def test_pipeline(query: str):
     logging.info(f"📌 Expresión lógica generada: {logical_query}")
 
     # Paso 2: Clasificar la categoría automáticamente
-    category = classify_query(query)
+    client = AIClient("Gemini")
+    category = client.classify_query(query)
     logging.info(f"📂 Categoría detectada: {category}")
 
     # Paso 3: Procesar los términos y convertirlos en operadores de VT Intelligence


### PR DESCRIPTION
La idea original de tener un método diferente para Ollama y Gemini ha sido envuelta en una única clase llamada AIClient. 
Con esto se logra modularizar el proceso y facilitar las futuras posibles modificaciones de modelos y proveedores usados.
También permite llamar a un método `query_ai` que es transparente al proveedor elegido, una vez se haya inicializado.
Se han adecuado el resto de métodos a la sintaxis de la nueva estructura creada.